### PR TITLE
Edited README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,34 @@
 # haskell-multihash
 
-[![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](http://github.com/multiformats/multiformats)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
+[![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](https://github.com/multiformats/multiformats)
+[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](https://webchat.freenode.net/?channels=%23ipfs)
+[![](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 
 > Multihash Haskell implementation
 
 This is the Haskell implementation of [multihash](https://github.com/multiformats/multihash), by [@LukeHoersten](https://github.com/LukeHoersten).
 
-## Maintainer
+## Install
+
+TODO
+
+## Usage
+
+TODO
+
+## Maintainers
 
 [@LukeHoersten](https://github.com/LukeHoersten).
 
 ## Contribute
 
-Contribtutions welcome: please [open an issue](https://github.com/multiformats/haskell-multihash/issues).
+Contributions welcome: please [open an issue](https://github.com/multiformats/haskell-multihash/issues).
+
+Check out our [contributing document](https://github.com/multiformats/multiformats/blob/master/contributing.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to multiformats are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
+Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
 
 ## License
 
-[Copyright (c) 2015, Luke Hoersten](LICENSE)
+[Copyright](LICENSE) © 2015, Luke Hoersten
+


### PR DESCRIPTION
These are reflective of changes I'm doing across multiformats; some of them are stylistic, and some of them reflect the need for a few other things - a Code of Conduct, for instance. Install and Usage need more work; I'll open an issue for those. As well, it would be great to have code coverage and ci. But that is outside of the scope of this.

For now:

- Fix https issues for project and freenode badges.
- Added standard-readme badge.
- Changed `Maintainer` to `Maintainers` to match standard-readme.
- Added Install and Usage sections with TODOs.
- Fixed spelling error for contributions.
- Edited license text to match standard-readme.
- Added Contributing document for organization
- Added note about standard readme.
- Added link to IPFS Code of Conduct.