### PR TITLE
Remove upper bounds and add stack support

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -7,6 +7,7 @@ import qualified Crypto.Hash              as CH
 import           Data.Byteable            (toBytes)
 import           Data.ByteString          (ByteString)
 import           Data.ByteString.Lazy     (toStrict)
+import           Data.Monoid              ((<>))
 import           Options.Applicative
 
 import           System.IO.Streams        (InputStream, stdin, stdout,

--- a/multihash.cabal
+++ b/multihash.cabal
@@ -31,15 +31,15 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
 
-  build-depends: attoparsec        >= 0.12
-               , base              >= 4.7    && <  4.10
-               -- , base32-bytestring >= 0.2
-               , base58-bytestring >= 0.1
-               , base64-bytestring >= 1.0
-               , bytestring        >= 0.10
-               , cryptohash        >= 0.11
-               , hex               >= 0.1
-               , io-streams        >= 1.2
+  build-depends: attoparsec        >= 0.12   && < 0.14
+               , base              >= 4.7    && < 4.10
+               -- , base32-bytestring >= 0.2 
+               , base58-bytestring >= 0.1    && < 0.2
+               , base64-bytestring >= 1.0    && < 1.1
+               , bytestring        >= 0.10   && < 0.11
+               , cryptohash        >= 0.11   && < 0.12
+               , hex               >= 0.1    && < 0.2
+               , io-streams        >= 1.2    && < 1.4
 
 
 executable multihash
@@ -49,14 +49,14 @@ executable multihash
   ghc-options:       -threaded -Wall -fwarn-tabs -funbox-strict-fields -O2 -fdicts-cheap
                      -fno-warn-orphans -fno-warn-unused-do-bind -rtsopts
 
-  build-depends: base                 >= 4.7
+  build-depends: base                 >= 4.7  && < 4.10
                -- , base32-bytestring >= 0.2
-               , base64-bytestring    >= 1.0
-               , base58-bytestring    >= 0.1
-               , byteable             >= 0.1
-               , bytestring           >= 0.10
-               , cryptohash           >= 0.11
-               , hex                  >= 0.1 
-               , io-streams           >= 1.2
-               , multihash            >= 0.1
-               , optparse-applicative >= 0.11
+               , base64-bytestring    >= 1.0  && < 1.1
+               , base58-bytestring    >= 0.1  && < 0.2
+               , byteable             >= 0.1  && < 0.2
+               , bytestring           >= 0.10 && < 0.11
+               , cryptohash           >= 0.11 && < 0.12
+               , hex                  >= 0.1  && < 0.2
+               , io-streams           >= 1.2  && < 1.4
+               , multihash            >= 0.1 
+               , optparse-applicative >= 0.11 && < 0.14

--- a/multihash.cabal
+++ b/multihash.cabal
@@ -31,15 +31,15 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
 
-  build-depends: attoparsec        >= 0.12   && < 0.14
-               , base              >= 4.7    && < 4.10
-               -- , base32-bytestring >= 0.2 
-               , base58-bytestring >= 0.1    && < 0.2
-               , base64-bytestring >= 1.0    && < 1.1
-               , bytestring        >= 0.10   && < 0.11
-               , cryptohash        >= 0.11   && < 0.12
-               , hex               >= 0.1    && < 0.2
-               , io-streams        >= 1.2    && < 1.4
+  build-depends: attoparsec        >= 0.12 && < 0.14
+               , base              >= 4.7  && < 4.10
+               -- , base32-bytestring >= 0.2  && < 0.3
+               , base58-bytestring >= 0.1  && < 0.2
+               , base64-bytestring >= 1.0  && < 1.1
+               , bytestring        >= 0.10 && < 0.11
+               , cryptohash        >= 0.11 && < 0.12
+               , hex               >= 0.1  && < 0.2
+               , io-streams        >= 1.2  && < 1.4
 
 
 executable multihash
@@ -58,5 +58,5 @@ executable multihash
                , cryptohash           >= 0.11 && < 0.12
                , hex                  >= 0.1  && < 0.2
                , io-streams           >= 1.2  && < 1.4
-               , multihash            >= 0.1 
+               , multihash            >= 0.1  && < 0.2
                , optparse-applicative >= 0.11 && < 0.14

--- a/multihash.cabal
+++ b/multihash.cabal
@@ -32,7 +32,7 @@ library
   default-language:    Haskell2010
 
   build-depends: attoparsec        >= 0.12
-               , base              >= 4.7
+               , base              >= 4.7    && <  4.10
                -- , base32-bytestring >= 0.2
                , base58-bytestring >= 0.1
                , base64-bytestring >= 1.0

--- a/multihash.cabal
+++ b/multihash.cabal
@@ -1,5 +1,5 @@
 name:                multihash
-version:             0.1.1
+version:             0.1.3
 synopsis:            Multihash library and CLI executable
 description:         Multihash is a protocol for encoding the hash algorithm
                      and digest length at the start of the digest.
@@ -31,15 +31,15 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
 
-  build-depends: attoparsec        >= 0.12 && < 0.13
-               , base              >= 4.7  && < 4.9
-               -- , base32-bytestring >= 0.2  && < 0.3
-               , base58-bytestring >= 0.1  && < 0.2
-               , base64-bytestring >= 1.0  && < 1.1
-               , bytestring        >= 0.10 && < 0.11
-               , cryptohash        >= 0.11 && < 0.12
-               , hex               >= 0.1  && < 0.2
-               , io-streams        >= 1.2  && < 1.3
+  build-depends: attoparsec        >= 0.12
+               , base              >= 4.7
+               -- , base32-bytestring >= 0.2
+               , base58-bytestring >= 0.1
+               , base64-bytestring >= 1.0
+               , bytestring        >= 0.10
+               , cryptohash        >= 0.11
+               , hex               >= 0.1
+               , io-streams        >= 1.2
 
 
 executable multihash
@@ -49,14 +49,14 @@ executable multihash
   ghc-options:       -threaded -Wall -fwarn-tabs -funbox-strict-fields -O2 -fdicts-cheap
                      -fno-warn-orphans -fno-warn-unused-do-bind -rtsopts
 
-  build-depends: base                 >= 4.7  && < 4.9
-               -- , base32-bytestring >= 0.2  && < 0.3
-               , base64-bytestring    >= 1.0  && < 1.1
-               , base58-bytestring    >= 0.1  && < 0.2
-               , byteable             >= 0.1  && < 0.2
-               , bytestring           >= 0.10 && < 0.11
-               , cryptohash           >= 0.11 && < 0.12
-               , hex                  >= 0.1  && < 0.2
-               , io-streams           >= 1.2  && < 1.3
-               , multihash            >= 0.1  && < 0.2
-               , optparse-applicative >= 0.11 && < 0.12
+  build-depends: base                 >= 4.7
+               -- , base32-bytestring >= 0.2
+               , base64-bytestring    >= 1.0
+               , base58-bytestring    >= 0.1
+               , byteable             >= 0.1
+               , bytestring           >= 0.10
+               , cryptohash           >= 0.11
+               , hex                  >= 0.1 
+               , io-streams           >= 1.2
+               , multihash            >= 0.1
+               , optparse-applicative >= 0.11

--- a/src/Data/Multihash/Digest.hs
+++ b/src/Data/Multihash/Digest.hs
@@ -10,8 +10,6 @@ import           Data.ByteString.Builder    (Builder, byteString,
 import qualified Data.ByteString.Builder    as BB
 import qualified Data.ByteString.Lazy       as BL
 import           Data.Monoid                ((<>))
-import           Data.Word                  (Word8)
-
 
 data MultihashDigest =
     MultihashDigest

--- a/src/System/IO/Streams/Crypto.hs
+++ b/src/System/IO/Streams/Crypto.hs
@@ -1,11 +1,8 @@
 module System.IO.Streams.Crypto where
 
-import           Control.Exception     (bracket)
 import           Crypto.Hash           (Digest, HashAlgorithm (..))
 import           Data.ByteString       (ByteString)
-import           Data.Multihash.Digest (decoder)
-import           System.IO.Streams     (InputStream, fold, inputFoldM)
-
+import           System.IO.Streams     (InputStream, fold)
 
 hashInputStream :: (HashAlgorithm h) => InputStream ByteString -> IO (Digest h)
 hashInputStream = fmap hashFinalize . fold update hashInit

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.12
+resolver: lts-8.15
 packages:
 - '.'
 extra-deps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+resolver: lts-8.12
+packages:
+- '.'
+extra-deps:
+- base58-bytestring-0.1.0


### PR DESCRIPTION
This changeset allows us to use more recent versions of GHC as well as stack